### PR TITLE
Restore deleted plugin

### DIFF
--- a/pluginDefinition.json
+++ b/pluginDefinition.json
@@ -39,6 +39,16 @@
       "sourceName": "tn3270data",
       "sourcePlugin": "org.zowe.terminal.proxy",
       "versionRange": "^1.0.0"
+    },
+    {
+      "type": "service",
+      "name": "statediscovery",
+      "initializerLookupMethod": "internal",
+      "initializerName": "zosDiscoveryServiceInstaller",
+      "methods": [
+        "GET"
+      ],
+      "version": "1.0.0"
     }
   ]
 }


### PR DESCRIPTION
In #88 the state discovery plugin was deleted from the definition. This seems like a mistake. I know of no reason why this cannot be used in v3 and so I am restoring it.