### PR TITLE
Display LU Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Basic TN3270 Display Emulator Changelog
 
 ## `3.3.0`
-- Enhancement: LU name is displayed the windows title [#102](https://github.com/zowe/tn3270-ng2/pull/102)
+- Enhancement: LU name is displayed in the windows title [#101](https://github.com/zowe/tn3270-ng2/pull/101)
 
 ## `3.1.0`
 - Enhancement: Parameterized behavior of the Backspace key: move cursor only (default) or delete characters. Configurable via config or GUI. [#100](https://github.com/zowe/tn3270-ng2/pull/100)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Basic TN3270 Display Emulator Changelog
 
-## `3.0.1`
+## `3.3.0`
+- Enhancement: LU name is displayed the windows title [#102](https://github.com/zowe/tn3270-ng2/pull/102)
+
+## `3.1.0`
 - Enhancement: Parameterized behavior of the Backspace key: move cursor only (default) or delete characters. Configurable via config or GUI. [#100](https://github.com/zowe/tn3270-ng2/pull/100)
 
 ## `3.0.0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "tn3270.pr.luname",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -26,6 +26,7 @@ const CONFIG_MENU_ROW_PX = 40;
 const CONFIG_MENU_PAD_PX = 4;
 
 const TITLE_PREFIX = 'TN3270 - ';
+// Waiting in backround => other processing is not affected by this
 const LUNAME_MAX_ATTEMPTS = 24;
 const LUNAME_WAIT_TIME = 2500;
 

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -100,6 +100,7 @@ export class AppComponent implements AfterViewInit {
   private terminalHeightOffset: number = 0;
   private currentErrors: ErrorState = new ErrorState();
   disableButton: boolean;
+  private luAttempts = 0;
 
   constructor(
     private http: HttpClient,
@@ -476,14 +477,14 @@ export class AppComponent implements AfterViewInit {
     }
   }
 
-  private disconnectAndUnsetTitle() {
+  private disconnectAndUnsetTitle(): void {
     this.terminal.close();
     if (this.windowActions) {
       this.windowActions.setTitle(`${TITLE_PREFIX}Disconnected`);
     }
   }
 
-  private setWindowTitle(host: string, port: number, terminal: any) {
+  private setWindowTitle(host: string, port: number, terminal: any): void {
     let title = `${TITLE_PREFIX}${host}:${port}`;
     if (terminal && terminal.luname !== null) {
       title += ` [${terminal.luname}]`
@@ -493,8 +494,7 @@ export class AppComponent implements AfterViewInit {
     }
   }
 
-  private luAttempts = 0;
-  private waitForLUName(terminal: any) {
+  private waitForLUName(terminal: any): void {
     if (terminal && terminal.luname !== null) {
       return this.setWindowTitle(this.connectionSettings.host, this.connectionSettings.port, this.terminal);
     } else {
@@ -505,7 +505,7 @@ export class AppComponent implements AfterViewInit {
     }
   }
 
-  private connectAndSetTitle(connectionSettings:any) {
+  private connectAndSetTitle(connectionSettings: any): void {
     this.setWindowTitle(connectionSettings.host, connectionSettings.port, undefined);
     connectionSettings.charsetName = this.nameToCodepage(connectionSettings.charsetName);
     this.terminal.connectToHost(connectionSettings);
@@ -514,7 +514,7 @@ export class AppComponent implements AfterViewInit {
     this.waitForLUName(this.terminal);
   }
 
-  private nameToCodepage(name) {
+  private nameToCodepage(name: any): string|undefined {
     const stringName = isNaN(Number(name)) ? name : ''+name;
     for (let i = 0; i < this.charsets.length; i++) {
       if ((this.charsets[i].name == stringName) || (this.charsets[i].name.startsWith(stringName+':'))) {

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -24,7 +24,10 @@ import './app.component.css';
 const TOGGLE_MENU_BUTTON_PX = 16; //with padding
 const CONFIG_MENU_ROW_PX = 40;
 const CONFIG_MENU_PAD_PX = 4;
-const CONFIG_MENU_SIZE_PX = (CONFIG_MENU_ROW_PX*3)+CONFIG_MENU_PAD_PX; //40 per row, plus 2 px padding
+
+const TITLE_PREFIX = 'TN3270 - ';
+const LUNAME_MAX_ATTEMPTS = 24;
+const LUNAME_WAIT_TIME = 2500;
 
 enum ErrorType {
   host,
@@ -475,15 +478,40 @@ export class AppComponent implements AfterViewInit {
 
   private disconnectAndUnsetTitle() {
     this.terminal.close();
-    if (this.windowActions) {this.windowActions.setTitle(`TN3270 - Disconnected`);}
+    if (this.windowActions) {
+      this.windowActions.setTitle(`${TITLE_PREFIX}Disconnected`);
+    }
+  }
+
+  private setWindowTitle(host: string, port: number, terminal: any) {
+    let title = `${TITLE_PREFIX}${host}:${port}`;
+    if (terminal && terminal.luname !== null) {
+      title += ` [${terminal.luname}]`
+    }
+    if (this.windowActions) {
+      this.windowActions.setTitle(title);
+    }
+  }
+
+  private luAttempts = 0;
+  private waitForLUName(terminal: any) {
+    if (terminal && terminal.luname !== null) {
+      return this.setWindowTitle(this.connectionSettings.host, this.connectionSettings.port, this.terminal);
+    } else {
+      this.luAttempts ++;
+      if (this.luAttempts < LUNAME_MAX_ATTEMPTS) {
+        setTimeout(() => { this.waitForLUName(terminal); }, LUNAME_WAIT_TIME);
+      }
+    }
   }
 
   private connectAndSetTitle(connectionSettings:any) {
-    if (this.windowActions) {
-      this.windowActions.setTitle(`TN3270 - ${connectionSettings.host}:${connectionSettings.port}`);
-    }
+    this.setWindowTitle(connectionSettings.host, connectionSettings.port, undefined);
     connectionSettings.charsetName = this.nameToCodepage(connectionSettings.charsetName);
     this.terminal.connectToHost(connectionSettings);
+    this.luAttempts = 0;
+    this.terminal.luname = null;
+    this.waitForLUName(this.terminal);
   }
 
   private nameToCodepage(name) {

--- a/webClient/src/app/terminal.ts
+++ b/webClient/src/app/terminal.ts
@@ -47,6 +47,7 @@ export type TerminalWebsocketError = {
 
 export class Terminal {
   virtualScreen: any;
+  luname: string;
   contextMenuEmitter: Subject<any> = new Subject();
   wsErrorEmitter: Subject<TerminalWebsocketError> = new Subject();
   constructor(
@@ -75,6 +76,7 @@ export class Terminal {
     let latestContext = {};
     const screenLoadedCallback = () => {
       helper.getAll(this.virtualScreen.getLUName()).subscribe(data=> {
+        this.luname = this.virtualScreen.getLUName();
         if (data?.rows?.length === 1) {
           latestContext = data.rows[0];
           this.log.debug("screenContext from discovery="+JSON.stringify(latestContext, null, 2));
@@ -121,6 +123,7 @@ export class Terminal {
       this.virtualScreen.closeConnection(4000, "Closed by user");
     }
     this.virtualScreen = null;
+    this.luname = null;
   }
 
   performResize() {

--- a/webClient/webpack.config.js
+++ b/webClient/webpack.config.js
@@ -2,20 +2,29 @@
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 */
 
-if (process.env.MVD_DESKTOP_DIR == null) {
-  throw new Error('You must specify MVD_DESKTOP_DIR in your environment');
+const path = require('path');
+
+let baseConfig;
+let mvdDesktopDir = process.env.MVD_DESKTOP_DIR;
+
+if (!mvdDesktopDir) {
+  mvdDesktopDir = '../../zlux-app-manager/virtual-desktop';
 }
 
-const path = require('path');
+try {
+  baseConfig = require(path.resolve(mvdDesktopDir, 'plugin-config/webpack5.base.js'));
+} catch {
+  throw new Error(`You must specify MVD_DESKTOP_DIR in your environment. MVD_DESKTOP_DIR="${process.env.MVD_DESKTOP_DIR}" is not a valid path.`);
+}
+
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
-const baseConfig = require(path.resolve(process.env.MVD_DESKTOP_DIR, 'plugin-config/webpack5.base.js'));
 const AotPlugin = require('@ngtools/webpack').AngularWebpackPlugin;
 
 const config = {
@@ -90,8 +99,8 @@ module.exports = deepMerge(baseConfig, config);
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 */


### PR DESCRIPTION
Fixes https://github.com/zowe/zlux/issues/1044.

## Changes

### LU name
* When setting the window title, set the host and port
* Wait for LU name
  * Once available, update the title
  * Wait for certain number of attempts in case, the LU name is not available or detected

### Other - Webpack changes
* When the `MVD_DESKTOP_DIR` is not set, try to use the desktop two dir levels up (`../../zlux-app-manager/virtual-desktop`)
* This path is expected, when `lint` is used

### UI Change
Just the title is extended to show the LU name.
The CA TPX is displaying the LU name in the initial screen.
![image](https://github.com/user-attachments/assets/b4cc318b-7fbd-4220-bb6e-7009b688bf10)
