### PR TITLE
Add optional LU name configuration for TN3270 sessions

### DIFF
--- a/config/storageDefaults/sessions/_defaultTN3270.json
+++ b/config/storageDefaults/sessions/_defaultTN3270.json
@@ -3,5 +3,6 @@
   "port": 23,
   "security": {
     "type": "telnet"
-  }
+  },
+  "luname": ""
 }

--- a/webClient/src/app/app.component.html
+++ b/webClient/src/app/app.component.html
@@ -66,10 +66,14 @@
           <input type="number" [disabled]="!isDynamic || isInputDisabled" required min="1" max="16383" class="form-control" (input)="validateScreenDimension()" [(ngModel)]="row">
         </div>
         <label class="col-sm-2 col-form-label">Codepage</label>
-        <div class="toolbar-input col-sm-4">
+        <div class="toolbar-input col-sm-2">
           <select [(ngModel)]="selectedCodepage" [disabled]="isInputDisabled" class="form-control">
             <option [ngValue]="i.name" *ngFor="let i of charsets">{{i.name}}</option>
           </select>
+        </div>
+        <label class="col-sm-1 col-form-label">LU Name</label>
+        <div class="toolbar-input col-sm-1">
+          <input class="form-control" [disabled]="isInputDisabled" maxlength="8" placeholder="" [(ngModel)]="luname">
         </div>
         <button class="terminal-button save-button" type="submit" (click)="saveSettings()">
           <i class="fa fa-save"></i>

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -85,6 +85,7 @@ export class AppComponent implements AfterViewInit {
   port:number;
   securityType:string;
   modType: string;
+  luname: string = '';
   connectionSettings: any;
   errorMessage: string = '';
   isDynamic: boolean;
@@ -128,6 +129,7 @@ export class AppComponent implements AfterViewInit {
             this.row = cs.alternateHeight ? cs.alternateHeight : 24;
             this.column = cs.alternateWidth ? cs.alternateWidth : 80;
           }
+          if (cs.luname) { this.luname = cs.luname; }
           this.connectionSettings = cs;
         }
         break;
@@ -204,6 +206,7 @@ export class AppComponent implements AfterViewInit {
         if (contents.alternateWidth) { this.column = contents.alternateWidth; }
         if (contents.charsetName) { this.selectedCodepage = contents.charsetName; }
         if (contents.destructiveBackspace) { this.destructiveBackspace = contents.destructiveBackspace; }
+        if (contents.luname) { this.luname = contents.luname; }
         this.checkZssProxy().then(() => {
           this.connectionSettings = {
             host: this.host,
@@ -215,7 +218,8 @@ export class AppComponent implements AfterViewInit {
             alternateHeight: this.row,
             alternateWidth: this.column,
             charsetName: this.selectedCodepage,
-            destructiveBackspace: this.destructiveBackspace
+            destructiveBackspace: this.destructiveBackspace,
+            sessionDeviceName: this.luname || undefined
           }
           this.connectAndSetTitle(this.connectionSettings);
         })
@@ -238,7 +242,8 @@ export class AppComponent implements AfterViewInit {
         alternateHeight: this.row,
         alternateWidth: this.column,
         charsetName: this.selectedCodepage,
-        destructiveBackspace: this.destructiveBackspace
+        destructiveBackspace: this.destructiveBackspace,
+        sessionDeviceName: this.luname || undefined
       }, this.connectionSettings));
     }
     log.debug('END: Tn3270 ngAfterViewInit');
@@ -473,7 +478,8 @@ export class AppComponent implements AfterViewInit {
         alternateHeight: this.row,
         alternateWidth: this.column,
         charsetName: this.selectedCodepage,
-        destructiveBackspace: this.destructiveBackspace
+        destructiveBackspace: this.destructiveBackspace,
+        sessionDeviceName: this.luname || undefined
       });
     }
   }
@@ -608,7 +614,8 @@ export class AppComponent implements AfterViewInit {
         port: this.port,
         host: this.host,
         charsetName: this.selectedCodepage,
-        destructiveBackspace: this.destructiveBackspace
+        destructiveBackspace: this.destructiveBackspace,
+        luname: this.luname || ''
       }).subscribe((result: any)=> {
         this.log.debug('Save return');
     });

--- a/webClient/src/app/terminal.config.ts
+++ b/webClient/src/app/terminal.config.ts
@@ -19,7 +19,8 @@ export class TerminalConfig {
     public alternateHeight?: number,
     public alternateWidth?: number,
     public charsetName?: string,
-    public destructiveBackspace?: boolean
+    public destructiveBackspace?: boolean,
+    public luname?: string
   ) {
 
   }


### PR DESCRIPTION
## Summary
- Adds an optional `luname` field to TN3270 session configuration and saved user settings.
- Adds an `LU Name` input to the connection toolbar.
- Passes the requested LU name to the existing TN3270 client `sessionDeviceName` setting when present, preserving automatic LU assignment when blank.

## Test plan
- Confirmed the underlying TN3270 client already supports `connectionSettings.sessionDeviceName` for TN3270E device-name negotiation.
- Ran standalone TypeScript check for `webClient/src/app/terminal.config.ts`.
- Checked Cursor lints for changed Angular files; no linter errors reported.

## Notes
- Full standalone Angular build/TSLint require sibling Zowe framework repos such as `zlux-app-manager`, so they could not be completed from this isolated clone.
- This repo does not contain `ZWED_TN3270_*` environment-variable templating; adding `ZWED_TN3270_LUNAME` likely belongs in the Zowe packaging/config repo.

Made with [Cursor](https://cursor.com)