### PR TITLE
Update debug log to show prompt value length only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Basic TN3270 Display Emulator Changelog
 
+## `3.6.0`
+- Bugfix: Do not log prompt value in debug mode [#107](https://github.com/zowe/tn3270-ng2/pull/107)
+
 ## `3.3.0`
 - Enhancement: LU name is displayed in the windows title [#101](https://github.com/zowe/tn3270-ng2/pull/101)
 

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -424,7 +424,7 @@ export class AppComponent implements AfterViewInit {
     if (keys.prompt) {
       this.keySequncesLogDebug(keys);
       const promptValue = prompt(keys.prompt, '');
-      this.log.debug(`Value: ${promptValue}`);
+      this.log.debug(`Prompt value of length ${promptValue.length}`);
       for (let char = 0; char < promptValue.length; char++) {
         textAreaElement.dispatchEvent(new KeyboardEvent('keydown', {'key': promptValue[char]}));
       }


### PR DESCRIPTION
There is a debug option for key sequences feature.

When the prompt is used, the value could be visible in log. The prompt might be a sensitive information, let's print only debug message indicating the prompt was processed.

