### PR TITLE
Fallback security type condition to `tls`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Basic TN3270 Display Emulator Changelog
 
+## `3.6.0`
+- Bugfix: if unknown security options is specified, fallback to `tls` [#109](https://github.com/zowe/tn3270-ng2/pull/109)
+
 ## `3.3.0`
 - Enhancement: LU name is displayed in the windows title [#101](https://github.com/zowe/tn3270-ng2/pull/101)
 

--- a/webClient/src/app/terminal.ts
+++ b/webClient/src/app/terminal.ts
@@ -70,7 +70,7 @@ export class Terminal {
 
     connectionSettings.url = ZoweZLUX.uriBroker.pluginWSUri(plugin, 'terminalstream', '');
     connectionSettings.connect = true;
-    connectionSettings.security.type = connectionSettings.security.type == 'tls' ? 2 : 0;
+    connectionSettings.security.type = connectionSettings.security.type == 'telnet' ? 0 : 2;
     // logic for using dispatcher goes here
     // should be in Tn3270Service.js eventually
     let latestContext = {};


### PR DESCRIPTION
Before the change, any security misconfiguration will use `telnet`, for example for `TLS` the telnet is used.
```javascript
connectionSettings.security.type = connectionSettings.security.type == 'tls' ? 2 : 0;
```

After the change, use `telnet` for one specific case, otherwise use `tls`:
```javascript
connectionSettings.security.type = connectionSettings.security.type == 'telnet' ? 0 : 2;
```

Idea is to rather to fallback to secured connection than "plain text" type of connection.