### PR TITLE
use env value for zss

### DIFF
--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -17,7 +17,7 @@ declare var org_zowe_terminal_tn3270: any;
 import { Angular2InjectionTokens, Angular2PluginWindowActions, Angular2PluginViewportEvents, ContextMenuItem } from 'pluginlib/inject-resources';
 
 import { Terminal, TerminalWebsocketError} from './terminal';
-import { ConfigServiceTerminalConfig, ZssConfig, KeySequencesConfig, KeySequence, Keys } from './terminal.config';
+import { ConfigServiceTerminalConfig, KeySequencesConfig, KeySequence, Keys } from './terminal.config';
 
 import './app.component.css';
 
@@ -358,12 +358,17 @@ export class AppComponent implements AfterViewInit {
   checkZssProxy(): Promise<any> {
     return new Promise((resolve, reject) => {
       if (this.host === "") {
-        this.loadZssSettings().subscribe((zssSettings: ZssConfig) => {
-          this.host = zssSettings.zssServerHostName;
-          resolve(this.host);
-        }, () => {
-          this.setError(ErrorType.host, "Invalid Hostname: \"" + this.host + "\".")
-          reject(this.host)
+        ZoweZLUX.environment.getAgentHost().then((agentHost) => {
+          if (agentHost) {
+            this.host = agentHost;
+            resolve(this.host);
+          } else {
+            this.setError(ErrorType.host, "Invalid Hostname: \"" + this.host + "\".");
+            reject(this.host);
+          }
+        }).catch(() => {
+          this.setError(ErrorType.host, "Invalid Hostname: \"" + this.host + "\".");
+          reject(this.host);
         });
       } else {
         resolve(this.host);
@@ -590,10 +595,6 @@ export class AppComponent implements AfterViewInit {
   loadConfig(): Observable<ConfigServiceTerminalConfig> {
     this.log.warn("Config load is wrong and not abstracted");
     return this.http.get<ConfigServiceTerminalConfig>(ZoweZLUX.uriBroker.pluginConfigForScopeUri(this.pluginDefinition.getBasePlugin(),'user','sessions','_defaultTN3270.json'))
-  }
-
-  loadZssSettings(): Observable<ZssConfig> {
-    return this.http.get<ZssConfig>(ZoweZLUX.uriBroker.serverRootUri("server/proxies"))
   }
 
   saveSettings() {

--- a/webClient/src/app/terminal.config.ts
+++ b/webClient/src/app/terminal.config.ts
@@ -44,14 +44,6 @@ export class ConfigServiceTerminalConfig {
   }
 }
 
-export class ZssConfig {
-  constructor(
-    public zssServerHostName: string,
-    public zssPort: string
-  ) {
-  }
-}
-
 export class Keys {
   constructor(
     public normal?: string,


### PR DESCRIPTION
## Proposed changes

Replaces the `/server/proxies` HTTP call used to look up the ZSS hostname with `ZoweZLUX.environment.getAgentHost()`, and removes the now-unused `ZssConfig` class and `loadZssSettings()` method.

When the TN3270 terminal is opened without an explicit host configured (i.e. `host === ""`), it previously called the `/server/proxies` endpoint via `loadZssSettings()` to obtain the ZSS hostname. That endpoint has been removed in a companion PR to zlux-server-framework. The ZSS hostname is now available through the standard `ZoweZLUX.environment.getAgentHost()` API added in a companion PR to zlux-platform.

`checkZssProxy()` has been updated to call `ZoweZLUX.environment.getAgentHost()` and assign the resolved value to `this.host`. Error handling preserves the same behavior as before: a missing or rejected host surfaces an `ErrorType.host` message in the UI. The rest of the connection flow (`connectAndSetTitle`, etc.) is unchanged.

This PR addresses Issue: N/A

This PR depends upon the following PRs:
- [zlux-server-framework](https://github.com/zowe/zlux-server-framework/pull/703) — removes `/server/proxies`, adds `agent.host` to `/server/environment` response
- [zlux-platform](https://github.com/zowe/zlux-platform/pull/124) — adds `ZLUX.Environment.getAgentHost()` interface method and implementation

**Files changed:**
- `webClient/src/app/app.component.ts` — updated `checkZssProxy()` to use `ZoweZLUX.environment.getAgentHost()`; removed `loadZssSettings()` method; removed `ZssConfig` from import
- `webClient/src/app/terminal.config.ts` — removed `ZssConfig` class

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor the code

## PR Checklist

- [ ] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [ ] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

1. Build tn3270-ng2 against the updated zlux-platform and ensure no TypeScript compilation errors.
2. Deploy alongside the updated zlux-server-framework.
3. Open the TN3270 terminal app without a saved host configuration (or with an empty host).
4. Confirm the terminal auto-connects to the correct ZSS host.
5. Confirm no request is made to `/server/proxies` in the browser Network tab.
6. Confirm that configuring an explicit host in the settings panel still works (the `else` branch in `checkZssProxy` is unchanged).
7. Simulate a failure (e.g. disconnect the agent) and confirm that the error bar displays the expected "Invalid Hostname" message.

## Further comments

This change depends on `ZoweZLUX.environment.getAgentHost()` which is available after the Zowe Desktop bootstraps (i.e. within `ngAfterViewInit`, as used here). No timing issues are expected since the environment cache is populated on first access.
